### PR TITLE
Ability to configure JVM

### DIFF
--- a/lib/Bio/ENA/DataSubmission/CommandLine/SubmitAnalysisObjectsViaCli.pm
+++ b/lib/Bio/ENA/DataSubmission/CommandLine/SubmitAnalysisObjectsViaCli.pm
@@ -42,33 +42,33 @@ use Bio::ENA::DataSubmission::ConfigReader;
 
 has 'config_reader' => (is => 'ro', isa => 'Bio::ENA::DataSubmission::ConfigReader', required => 0, default =>
     sub {return Bio::ENA::DataSubmission::ConfigReader->new();});
-has 'manifest'      => (is => 'ro', isa => 'Str', required => 1);
-has 'input_dir'     => (is => 'ro', isa => 'Str', required => 1);
-has 'output_dir'    => (is => 'ro', isa => 'Str', required => 1);
-has 'validate'      => (is => 'ro', isa => 'Bool', required => 0, default => 1);
-has 'test'          => (is => 'ro', isa => 'Bool', required => 0, default => 0);
-has 'context'       => (is => 'rw', isa => 'Str',  required => 0, default    => 'genome' );
+has 'manifest' => (is => 'ro', isa => 'Str', required => 1);
+has 'input_dir' => (is => 'ro', isa => 'Str', required => 1);
+has 'output_dir' => (is => 'ro', isa => 'Str', required => 1);
+has 'validate' => (is => 'ro', isa => 'Bool', required => 0, default => 1);
+has 'test' => (is => 'ro', isa => 'Bool', required => 0, default => 0);
+has 'context' => (is => 'ro', isa => 'Str', required => 0, default => 'genome');
 
 around BUILDARGS => sub {
     my ($orig, $class, %args) = @_;
     if (exists $args{args}) {
         my $arguments = $args{args};
-        my($manifest, $output_dir, $input_dir, $context, $no_validate, $test, $config_file, $help);
+        my ($manifest, $output_dir, $input_dir, $context, $no_validate, $test, $config_file, $help);
 
         GetOptionsFromArray(
             $arguments,
-            'f|file=s'    => \$manifest,
-            'o|output_dir=s' => \$output_dir,
-            'i|input_dir=s' => \$input_dir,
-            't|type=s'      => \$context,
-            'no_validate' => \$no_validate,
-            'test' => \$test,
+            'f|file=s'        => \$manifest,
+            'o|output_dir=s'  => \$output_dir,
+            'i|input_dir=s'   => \$input_dir,
+            't|type=s'        => \$context,
+            'no_validate'     => \$no_validate,
+            'test'            => \$test,
             'c|config_file=s' => \$config_file,
-            'h|help'      => \$help
+            'h|help'          => \$help
         );
 
-        if (defined $help || ! defined $manifest || ! defined $output_dir || ! defined $input_dir) {
-            Bio::ENA::DataSubmission::Exception::InvalidInput->throw( error => USAGE );
+        if (defined $help || !defined $manifest || !defined $output_dir || !defined $input_dir) {
+            Bio::ENA::DataSubmission::Exception::InvalidInput->throw(error => USAGE);
         }
 
         $args{manifest} = $manifest;
@@ -108,8 +108,8 @@ sub BUILD {
         validate        => $self->validate,
         test            => $self->test,
         context         => $self->context,
+        jvm             => $config->{jvm},
     );
-
 
 }
 

--- a/lib/Bio/ENA/DataSubmission/CommandLine/SubmitAnalysisObjectsViaCli.pm
+++ b/lib/Bio/ENA/DataSubmission/CommandLine/SubmitAnalysisObjectsViaCli.pm
@@ -45,9 +45,9 @@ has 'config_reader' => (is => 'ro', isa => 'Bio::ENA::DataSubmission::ConfigRead
 has 'manifest' => (is => 'ro', isa => 'Str', required => 1);
 has 'input_dir' => (is => 'ro', isa => 'Str', required => 1);
 has 'output_dir' => (is => 'ro', isa => 'Str', required => 1);
-has 'validate' => (is => 'ro', isa => 'Bool', required => 0, default => 1);
-has 'test' => (is => 'ro', isa => 'Bool', required => 0, default => 0);
-has 'context' => (is => 'ro', isa => 'Str', required => 0, default => 'genome');
+has 'validate' => (is => 'ro', isa => 'Bool', required => 1);
+has 'test' => (is => 'ro', isa => 'Bool', required => 1);
+has 'context' => (is => 'ro', isa => 'Str', required => 1);
 
 around BUILDARGS => sub {
     my ($orig, $class, %args) = @_;
@@ -74,15 +74,9 @@ around BUILDARGS => sub {
         $args{manifest} = $manifest;
         $args{output_dir} = $output_dir;
         $args{input_dir} = $input_dir;
-        if (defined $context) {
-            $args{context} = $context;
-        }
-        if (defined $no_validate) {
-            $args{validate} = 0;
-        }
-        if (defined $test) {
-            $args{test} = 1;
-        }
+        $args{context} = (defined $context) ? $context : "genome";
+        $args{validate} = (defined $no_validate) ? 0 : 1;
+        $args{test} = (defined $test) ? 1 : 0;
         if (defined $config_file) {
             $args{config_reader} = Bio::ENA::DataSubmission::ConfigReader->new(config_file => $config_file);
         }
@@ -109,6 +103,7 @@ sub BUILD {
         test            => $self->test,
         context         => $self->context,
         jvm             => $config->{jvm},
+        submit          => 1,
     );
 
 }

--- a/lib/Bio/ENA/DataSubmission/WEBINCli.pm
+++ b/lib/Bio/ENA/DataSubmission/WEBINCli.pm
@@ -17,18 +17,19 @@ Wrapper around ENA's webin cli for analysis submissions
 use Moose;
 use Bio::ENA::DataSubmission::Exception;
 
-has 'jar_path' => (is => 'rw', isa => 'Str', required => 1);
-has 'username' => (is => 'rw', isa => 'Str', required => 1);
-has 'password' => (is => 'rw', isa => 'Str', required => 1);
-has 'http_proxy_host' => (is => 'rw', isa => 'Str', required => 1);
-has 'http_proxy_port' => (is => 'rw', isa => 'Int', required => 1);
-has 'context' => (is => 'rw', isa => 'Str', required => 0, default => 'genome');
-has 'input_dir' => (is => 'rw', isa => 'Str', required => 1);
-has 'output_dir' => (is => 'rw', isa => 'Str', required => 1);
-has 'manifest' => (is => 'rw', isa => 'Str', required => 1);
-has 'test' => (is => 'rw', isa => 'Bool', required => 0, default => 0);
-has 'validate' => (is => 'rw', isa => 'Bool', required => 0, default => 1);
-has 'submit' => (is => 'rw', isa => 'Bool', required => 0, default => 1);
+has 'jar_path' => (is => 'ro', isa => 'Str', required => 1);
+has 'username' => (is => 'ro', isa => 'Str', required => 1);
+has 'password' => (is => 'ro', isa => 'Str', required => 1);
+has 'http_proxy_host' => (is => 'ro', isa => 'Str', required => 1);
+has 'http_proxy_port' => (is => 'ro', isa => 'Int', required => 1);
+has 'context' => (is => 'ro', isa => 'Str', required => 0, default => 'genome');
+has 'input_dir' => (is => 'ro', isa => 'Str', required => 1);
+has 'output_dir' => (is => 'ro', isa => 'Str', required => 1);
+has 'manifest' => (is => 'ro', isa => 'Str', required => 1);
+has 'test' => (is => 'ro', isa => 'Bool', required => 0, default => 0);
+has 'validate' => (is => 'ro', isa => 'Bool', required => 0, default => 1);
+has 'submit' => (is => 'ro', isa => 'Bool', required => 0, default => 1);
+has 'jvm' => (is => 'ro', isa => 'Str', required => 1);
 
 sub run {
     my ($self) = @_;
@@ -50,7 +51,7 @@ sub _validate {
 sub _build_arguments_to_system_call {
     my ($self) = @_;
 
-    my @args = ("java", "-Dhttp.proxyHost=" . $self->http_proxy_host, "-Dhttp.proxyPort=" . $self->http_proxy_port,
+    my @args = ($self->jvm, "-Dhttp.proxyHost=" . $self->http_proxy_host, "-Dhttp.proxyPort=" . $self->http_proxy_port,
         "-jar", $self->jar_path, "-username", $self->username, "-password", $self->password, "-inputDir",
         $self->input_dir, "-outputDir", $self->output_dir, "-manifest", $self->manifest, "-context", $self->context);
     if ($self->test) {

--- a/lib/Bio/ENA/DataSubmission/WEBINCli.pm
+++ b/lib/Bio/ENA/DataSubmission/WEBINCli.pm
@@ -22,13 +22,13 @@ has 'username' => (is => 'ro', isa => 'Str', required => 1);
 has 'password' => (is => 'ro', isa => 'Str', required => 1);
 has 'http_proxy_host' => (is => 'ro', isa => 'Str', required => 1);
 has 'http_proxy_port' => (is => 'ro', isa => 'Int', required => 1);
-has 'context' => (is => 'ro', isa => 'Str', required => 0, default => 'genome');
+has 'context' => (is => 'ro', isa => 'Str', required => 1);
 has 'input_dir' => (is => 'ro', isa => 'Str', required => 1);
 has 'output_dir' => (is => 'ro', isa => 'Str', required => 1);
 has 'manifest' => (is => 'ro', isa => 'Str', required => 1);
-has 'test' => (is => 'ro', isa => 'Bool', required => 0, default => 0);
-has 'validate' => (is => 'ro', isa => 'Bool', required => 0, default => 1);
-has 'submit' => (is => 'ro', isa => 'Bool', required => 0, default => 1);
+has 'test' => (is => 'ro', isa => 'Bool', required => 1);
+has 'validate' => (is => 'ro', isa => 'Bool', required => 1);
+has 'submit' => (is => 'ro', isa => 'Bool', required => 1);
 has 'jvm' => (is => 'ro', isa => 'Str', required => 1);
 
 sub run {

--- a/t/Bio/ENA/DataSubmission/CommandLine/SubmitAnalysisObjectsViaCli.t
+++ b/t/Bio/ENA/DataSubmission/CommandLine/SubmitAnalysisObjectsViaCli.t
@@ -19,14 +19,15 @@ my $config = {
     'webin_pass'    => 'pass',
     'webin_cli_jar' => 't/bin/webin-cli-1.6.0.jar',
     'proxy'         => 'http://wwwcache.sanger.ac.uk:3128',
+    'jvm'           => 'customjava',
 };
 mock_class 'Bio::ENA::DataSubmission::ConfigReader' => 'Bio::ENA::DataSubmission::ConfigReader::Mock';
 my $mock_config_reader = Bio::ENA::DataSubmission::ConfigReader::Mock->new;
 $mock_config_reader->mock_return(get_config => $config, args => []);
 my ($manifest_file, $manifest_filename) = tempfile(CLEANUP => 1);
-my $temp_input_dir = File::Temp->newdir(CLEANUP => 1 );
+my $temp_input_dir = File::Temp->newdir(CLEANUP => 1);
 my $temp_input_dir_name = $temp_input_dir->dirname();
-my $temp_output_dir = File::Temp->newdir(CLEANUP => 1 );
+my $temp_output_dir = File::Temp->newdir(CLEANUP => 1);
 my $temp_output_dir_name = $temp_output_dir->dirname();
 
 my %full_args = (
@@ -79,7 +80,7 @@ my %full_args = (
     can_override_test($args);
 }
 
-# Test can override test uing direct input
+# Test can override test using direct input
 {
     my $args = { %full_args };
     $args->{test} = 1;
@@ -90,7 +91,7 @@ my %full_args = (
 {
 
     my $args = {
-        args => ['-f', $manifest_filename, '-i', $temp_input_dir_name, '-o', $temp_output_dir_name, '-c', 't/data/test_ena_data_submission.conf', '-t', 'another context']
+        args => [ '-f', $manifest_filename, '-i', $temp_input_dir_name, '-o', $temp_output_dir_name, '-c', 't/data/test_ena_data_submission.conf', '-t', 'another context' ]
     };
     can_change_the_context($args);
 }
@@ -121,6 +122,7 @@ sub can_build_cli_based_on_input {
     is($cli->test, 0, 'test is populated correctly');
     is($cli->validate, 1, 'validate is populated correctly');
     is($cli->submit, 1, 'submit is populated correctly');
+    is($cli->jvm, 'customjava', 'jvm is populated correctly');
 }
 sub can_suppress_validation {
     my ($args) = @_;
@@ -139,7 +141,9 @@ sub can_suppress_validation {
     is($cli->test, 0, 'test is populated correctly');
     is($cli->validate, 0, 'validate is populated correctly');
     is($cli->submit, 1, 'submit is populated correctly');
+    is($cli->jvm, 'customjava', 'jvm is populated correctly');
 }
+
 sub can_change_the_context {
     my ($args) = @_;
 
@@ -157,6 +161,7 @@ sub can_change_the_context {
     is($cli->test, 0, 'test is populated correctly');
     is($cli->validate, 1, 'validate is populated correctly');
     is($cli->submit, 1, 'submit is populated correctly');
+    is($cli->jvm, 'customjava', 'jvm is populated correctly');
 
 }
 sub can_override_test {
@@ -176,6 +181,7 @@ sub can_override_test {
     is($cli->test, 1, 'test is populated correctly');
     is($cli->validate, 1, 'validate is populated correctly');
     is($cli->submit, 1, 'submit is populated correctly');
+    is($cli->jvm, 'customjava', 'jvm is populated correctly');
 
 }
 sub test_mandatory_args {
@@ -197,7 +203,7 @@ sub test_mandatory_args {
 
 
 
-remove_tree($temp_input_dir_name, $temp_output_dir_name, $manifest_filename, );
+remove_tree($temp_input_dir_name, $temp_output_dir_name, $manifest_filename,);
 done_testing();
 
 no Moose;

--- a/t/Bio/ENA/DataSubmission/CommandLine/SubmitAnalysisObjectsViaCli.t
+++ b/t/Bio/ENA/DataSubmission/CommandLine/SubmitAnalysisObjectsViaCli.t
@@ -35,6 +35,9 @@ my %full_args = (
     manifest      => $manifest_filename,
     input_dir     => $temp_input_dir_name,
     output_dir    => $temp_output_dir_name,
+    context       => 'genome',
+    test          => 0,
+    validate      => 1,
 );
 
 
@@ -57,18 +60,12 @@ my %full_args = (
     };
     can_build_cli_based_on_input($args);
 }
+
 # Test can suppress validation using command line parameters
 {
     my $args = {
         args => [ '-f', $manifest_filename, '-i', $temp_input_dir_name, '-o', $temp_output_dir_name, '-c', 't/data/test_ena_data_submission.conf', '--no_validate' ]
     };
-    can_suppress_validation($args);
-}
-
-# Test can suppress validation using direct arguments
-{
-    my $args = { %full_args };
-    $args->{validate} = 0;
     can_suppress_validation($args);
 }
 
@@ -80,13 +77,6 @@ my %full_args = (
     can_override_test($args);
 }
 
-# Test can override test using direct input
-{
-    my $args = { %full_args };
-    $args->{test} = 1;
-    can_override_test($args);
-}
-
 # Test can change the context using command line args
 {
 
@@ -94,15 +84,6 @@ my %full_args = (
         args => [ '-f', $manifest_filename, '-i', $temp_input_dir_name, '-o', $temp_output_dir_name, '-c', 't/data/test_ena_data_submission.conf', '-t', 'another context' ]
     };
     can_change_the_context($args);
-}
-
-# Test can change the context using direct input
-{
-
-    my $args = { %full_args };
-    $args->{context} = 'another context';
-    can_change_the_context($args);
-
 }
 
 sub can_build_cli_based_on_input {

--- a/t/Bio/ENA/DataSubmission/WEBINCli.t
+++ b/t/Bio/ENA/DataSubmission/WEBINCli.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-BEGIN { unshift( @INC, './lib' ) }
+BEGIN {unshift(@INC, './lib')}
 
 BEGIN {
     use Test::Most;
@@ -13,38 +13,38 @@ use File::Temp qw(tempfile tempdir);
 use Data::Dumper;
 use File::Path qw(remove_tree);
 
-my $temp_input_dir = File::Temp->newdir(CLEANUP => 1 );
+my $temp_input_dir = File::Temp->newdir(CLEANUP => 1);
 my $temp_input_dir_name = $temp_input_dir->dirname();
-my $temp_output_dir = File::Temp->newdir(CLEANUP => 1 );
+my $temp_output_dir = File::Temp->newdir(CLEANUP => 1);
 my $temp_output_dir_name = $temp_output_dir->dirname();
-my($fh, $filename) = tempfile(CLEANUP => 1);
-my($manifest_file, $manifest_filename) = tempfile(CLEANUP => 1);
-my $temp_dir = File::Temp->newdir(CLEANUP => 1 );
+my ($fh, $filename) = tempfile(CLEANUP => 1);
+my ($manifest_file, $manifest_filename) = tempfile(CLEANUP => 1);
+my $temp_dir = File::Temp->newdir(CLEANUP => 1);
 my $temp_dir_name = $temp_dir->dirname();
-my($unreadable_manifest_handle, $unreadable_manifest) = tempfile(CLEANUP => 1);
+my ($unreadable_manifest_handle, $unreadable_manifest) = tempfile(CLEANUP => 1);
 chmod 0333, ($unreadable_manifest);
 use constant WEB_IN_CLIENT_JAR => "WEB_IN_CLIENT_JAR";
 use constant A_PROXY_HOST => "A_HOST";
 use constant A_PROXY_PORT => 1010;
 use constant A_USER => "A_USER";
 use constant A_PASSWORD => "A_PASSWORD";
+use constant JVM_PATH => "PATH/TO/JVM";
 
 my %full_args = (
     http_proxy_host => A_PROXY_HOST,
     http_proxy_port => A_PROXY_PORT,
-    username => A_USER,
-    password => A_PASSWORD,
-    jar_path => WEB_IN_CLIENT_JAR,
-    input_dir => $temp_input_dir_name,
-    output_dir => $temp_output_dir_name,
-    manifest => $manifest_filename,
+    username        => A_USER,
+    password        => A_PASSWORD,
+    jar_path        => WEB_IN_CLIENT_JAR,
+    input_dir       => $temp_input_dir_name,
+    output_dir      => $temp_output_dir_name,
+    manifest        => $manifest_filename,
+    jvm             => JVM_PATH,
 );
 
 #Mock the system function by capturing it's input
 my $system_call_args;
-use Test::Mock::Cmd 'system' => sub { $system_call_args = \@_ };
-
-
+use Test::Mock::Cmd 'system' => sub {$system_call_args = \@_};
 
 
 # Test the module can be used
@@ -58,76 +58,76 @@ use Test::Mock::Cmd 'system' => sub { $system_call_args = \@_ };
 
     my ($under_test) = Bio::ENA::DataSubmission::WEBINCli->new(%full_args);
     $under_test->run();
-    my $expected = ["java", "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
+    my $expected = [ JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
         A_USER, "-password", A_PASSWORD, "-inputDir", $temp_input_dir_name, "-outputDir", $temp_output_dir_name,
-        "-manifest", $manifest_filename, "-context", "genome", "-validate", "-submit"];
+        "-manifest", $manifest_filename, "-context", "genome", "-validate", "-submit" ];
     is_deeply($system_call_args, $expected, 'run() calls system() with correct arguments');
 }
 
 #Test can change the context
 {
 
-    my $args = {%full_args};
+    my $args = { %full_args };
     $args->{'context'} = 'a_context';
     my ($under_test) = Bio::ENA::DataSubmission::WEBINCli->new(%$args);
     $under_test->run();
-    my $expected = ["java", "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
+    my $expected = [ JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
         A_USER, "-password", A_PASSWORD, "-inputDir", $temp_input_dir_name, "-outputDir", $temp_output_dir_name,
-        "-manifest", $manifest_filename, "-context", "a_context", "-validate", "-submit"];
+        "-manifest", $manifest_filename, "-context", "a_context", "-validate", "-submit" ];
     is_deeply($system_call_args, $expected, 'run() calls system() with correct arguments');
 }
 
 #Test can change the test mode
 {
 
-    my $args = {%full_args};
+    my $args = { %full_args };
     $args->{'test'} = 1;
     my ($under_test) = Bio::ENA::DataSubmission::WEBINCli->new(%$args);
     $under_test->run();
-    my $expected = ["java", "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
+    my $expected = [ JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
         A_USER, "-password", A_PASSWORD, "-inputDir", $temp_input_dir_name, "-outputDir", $temp_output_dir_name,
-        "-manifest", $manifest_filename, "-context", "genome", "-test", "-validate", "-submit"];
+        "-manifest", $manifest_filename, "-context", "genome", "-test", "-validate", "-submit" ];
     is_deeply($system_call_args, $expected, 'run() calls system() with correct arguments');
 }
 
 #Test can switch off validation
 {
 
-    my $args = {%full_args};
+    my $args = { %full_args };
     $args->{'validate'} = 0;
     my ($under_test) = Bio::ENA::DataSubmission::WEBINCli->new(%$args);
     $under_test->run();
-    my $expected = ["java", "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
+    my $expected = [ JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
         A_USER, "-password", A_PASSWORD, "-inputDir", $temp_input_dir_name, "-outputDir", $temp_output_dir_name,
-        "-manifest", $manifest_filename, "-context", "genome", "-submit"];
+        "-manifest", $manifest_filename, "-context", "genome", "-submit" ];
     is_deeply($system_call_args, $expected, 'run() calls system() with correct arguments');
 }
 
 #Test can switch off submission
 {
 
-    my $args = {%full_args};
+    my $args = { %full_args };
     $args->{'submit'} = 0;
     my ($under_test) = Bio::ENA::DataSubmission::WEBINCli->new(%$args);
     $under_test->run();
-    my $expected = ["java", "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
+    my $expected = [ JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
         A_USER, "-password", A_PASSWORD, "-inputDir", $temp_input_dir_name, "-outputDir", $temp_output_dir_name,
-        "-manifest", $manifest_filename, "-context", "genome", "-validate"];
+        "-manifest", $manifest_filename, "-context", "genome", "-validate" ];
     is_deeply($system_call_args, $expected, 'run() calls system() with correct arguments');
 }
 
 
 sub test_mandatory_args {
     my ($input) = @_;
-    my $args_with_missing_required_arg = {%full_args};
+    my $args_with_missing_required_arg = { %full_args };
     delete $args_with_missing_required_arg->{$input};
     throws_ok {Bio::ENA::DataSubmission::WEBINCli->new(%$args_with_missing_required_arg)} 'Moose::Exception::AttributeIsRequired', "dies if mandatory arg $input is missing";
 }
 
 # Check mandatory arguments
 {
-    my (@mandatory_args) = ('input_dir','output_dir','manifest', 'http_proxy_host', 'http_proxy_port', 'username',
-        'password');
+    my (@mandatory_args) = ('input_dir', 'output_dir', 'manifest', 'http_proxy_host', 'http_proxy_port', 'username',
+        'password', 'jvm');
 
     foreach (@mandatory_args) {
         test_mandatory_args($_);
@@ -137,7 +137,7 @@ sub test_mandatory_args {
 
 # Fail non integer proxy port
 {
-    my $args = {%full_args};
+    my $args = { %full_args };
     $args->{"http_proxy_port"} = 13.3;
     throws_ok {Bio::ENA::DataSubmission::WEBINCli->new(%$args)} 'Moose::Exception::ValidationFailedForInlineTypeConstraint', "dies if http_proxy_port is not an int";
 }
@@ -145,7 +145,7 @@ sub test_mandatory_args {
 
 sub test_directory_missing {
     my ($input) = @_;
-    my $args = {%full_args};
+    my $args = { %full_args };
     $args->{$input} = 'Not/An/Existing/Directory';
     my $under_test = Bio::ENA::DataSubmission::WEBINCli->new(%$args);
     throws_ok {$under_test->run()} 'Bio::ENA::DataSubmission::Exception::DirectoryNotFound', "dies if $input is not found";
@@ -153,7 +153,7 @@ sub test_directory_missing {
 
 sub test_directory_not_a_directory {
     my ($input) = @_;
-    my $args = {%full_args};
+    my $args = { %full_args };
     $args->{$input} = $filename;
     my $under_test = Bio::ENA::DataSubmission::WEBINCli->new(%$args);
     throws_ok {$under_test->run()} 'Bio::ENA::DataSubmission::Exception::DirectoryNotFound', "dies if $input is a file and not a dir";
@@ -162,7 +162,7 @@ sub test_directory_not_a_directory {
 
 # Check directories validation
 {
-    my (@dir_args) = ('input_dir','output_dir');
+    my (@dir_args) = ('input_dir', 'output_dir');
     foreach (@dir_args) {
         test_directory_missing($_);
         test_directory_not_a_directory($_);
@@ -172,7 +172,7 @@ sub test_directory_not_a_directory {
 
 # Check manifest validation when missing
 {
-    my $args = {%full_args};
+    my $args = { %full_args };
     $args->{'manifest'} = 'Not/An/Existing/File';
     my $under_test = Bio::ENA::DataSubmission::WEBINCli->new(%$args);
     throws_ok {$under_test->run()} 'Bio::ENA::DataSubmission::Exception::FileNotFound', "dies if manifest is not found";
@@ -181,7 +181,7 @@ sub test_directory_not_a_directory {
 
 # Check manifest validation when not a file
 {
-    my $args = {%full_args};
+    my $args = { %full_args };
     $args->{'manifest'} = $temp_dir_name;
     my $under_test = Bio::ENA::DataSubmission::WEBINCli->new(%$args);
     throws_ok {$under_test->run()} 'Bio::ENA::DataSubmission::Exception::CannotReadFile', "dies if manifest is not a readable file";
@@ -190,7 +190,7 @@ sub test_directory_not_a_directory {
 
 # Check manifest validation when file is not readable
 {
-    my $args = {%full_args};
+    my $args = { %full_args };
     $args->{'manifest'} = $unreadable_manifest;
     my $under_test = Bio::ENA::DataSubmission::WEBINCli->new(%$args);
     throws_ok {$under_test->run()} 'Bio::ENA::DataSubmission::Exception::CannotReadFile', "dies if manifest is not a readable file";

--- a/t/Bio/ENA/DataSubmission/WEBINCli.t
+++ b/t/Bio/ENA/DataSubmission/WEBINCli.t
@@ -28,7 +28,8 @@ use constant A_PROXY_HOST => "A_HOST";
 use constant A_PROXY_PORT => 1010;
 use constant A_USER => "A_USER";
 use constant A_PASSWORD => "A_PASSWORD";
-use constant JVM_PATH => "PATH/TO/JVM";
+use constant A_JVM_PATH => "PATH/TO/JVM";
+use constant A_CONTEXT => "A_CONTEXT";
 
 my %full_args = (
     http_proxy_host => A_PROXY_HOST,
@@ -39,7 +40,11 @@ my %full_args = (
     input_dir       => $temp_input_dir_name,
     output_dir      => $temp_output_dir_name,
     manifest        => $manifest_filename,
-    jvm             => JVM_PATH,
+    jvm             => A_JVM_PATH,
+    context         => A_CONTEXT,
+    submit          => 1,
+    validate        => 1,
+    test            => 1,
 );
 
 #Mock the system function by capturing it's input
@@ -58,35 +63,22 @@ use Test::Mock::Cmd 'system' => sub {$system_call_args = \@_};
 
     my ($under_test) = Bio::ENA::DataSubmission::WEBINCli->new(%full_args);
     $under_test->run();
-    my $expected = [ JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
+    my $expected = [ A_JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
         A_USER, "-password", A_PASSWORD, "-inputDir", $temp_input_dir_name, "-outputDir", $temp_output_dir_name,
-        "-manifest", $manifest_filename, "-context", "genome", "-validate", "-submit" ];
+        "-manifest", $manifest_filename, "-context", A_CONTEXT, "-test", "-validate", "-submit" ];
     is_deeply($system_call_args, $expected, 'run() calls system() with correct arguments');
 }
 
-#Test can change the context
+#Test can switch off test mode
 {
 
     my $args = { %full_args };
-    $args->{'context'} = 'a_context';
+    $args->{'test'} = 0;
     my ($under_test) = Bio::ENA::DataSubmission::WEBINCli->new(%$args);
     $under_test->run();
-    my $expected = [ JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
+    my $expected = [ A_JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
         A_USER, "-password", A_PASSWORD, "-inputDir", $temp_input_dir_name, "-outputDir", $temp_output_dir_name,
-        "-manifest", $manifest_filename, "-context", "a_context", "-validate", "-submit" ];
-    is_deeply($system_call_args, $expected, 'run() calls system() with correct arguments');
-}
-
-#Test can change the test mode
-{
-
-    my $args = { %full_args };
-    $args->{'test'} = 1;
-    my ($under_test) = Bio::ENA::DataSubmission::WEBINCli->new(%$args);
-    $under_test->run();
-    my $expected = [ JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
-        A_USER, "-password", A_PASSWORD, "-inputDir", $temp_input_dir_name, "-outputDir", $temp_output_dir_name,
-        "-manifest", $manifest_filename, "-context", "genome", "-test", "-validate", "-submit" ];
+        "-manifest", $manifest_filename, "-context", A_CONTEXT, "-validate", "-submit" ];
     is_deeply($system_call_args, $expected, 'run() calls system() with correct arguments');
 }
 
@@ -97,9 +89,9 @@ use Test::Mock::Cmd 'system' => sub {$system_call_args = \@_};
     $args->{'validate'} = 0;
     my ($under_test) = Bio::ENA::DataSubmission::WEBINCli->new(%$args);
     $under_test->run();
-    my $expected = [ JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
+    my $expected = [ A_JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
         A_USER, "-password", A_PASSWORD, "-inputDir", $temp_input_dir_name, "-outputDir", $temp_output_dir_name,
-        "-manifest", $manifest_filename, "-context", "genome", "-submit" ];
+        "-manifest", $manifest_filename, "-context", A_CONTEXT, "-test", "-submit" ];
     is_deeply($system_call_args, $expected, 'run() calls system() with correct arguments');
 }
 
@@ -110,11 +102,12 @@ use Test::Mock::Cmd 'system' => sub {$system_call_args = \@_};
     $args->{'submit'} = 0;
     my ($under_test) = Bio::ENA::DataSubmission::WEBINCli->new(%$args);
     $under_test->run();
-    my $expected = [ JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
+    my $expected = [ A_JVM_PATH, "-Dhttp.proxyHost=A_HOST", "-Dhttp.proxyPort=1010", "-jar", WEB_IN_CLIENT_JAR, "-username",
         A_USER, "-password", A_PASSWORD, "-inputDir", $temp_input_dir_name, "-outputDir", $temp_output_dir_name,
-        "-manifest", $manifest_filename, "-context", "genome", "-validate" ];
+        "-manifest", $manifest_filename, "-context", A_CONTEXT, "-test", "-validate" ];
     is_deeply($system_call_args, $expected, 'run() calls system() with correct arguments');
 }
+
 
 
 sub test_mandatory_args {
@@ -127,7 +120,7 @@ sub test_mandatory_args {
 # Check mandatory arguments
 {
     my (@mandatory_args) = ('input_dir', 'output_dir', 'manifest', 'http_proxy_host', 'http_proxy_port', 'username',
-        'password', 'jvm');
+        'password', 'jvm', 'context', 'submit', 'validate');
 
     foreach (@mandatory_args) {
         test_mandatory_args($_);

--- a/t/data/test_ena_data_submission.conf
+++ b/t/data/test_ena_data_submission.conf
@@ -7,7 +7,7 @@
   'ena_dropbox_submission_url' => 'https://example.com/',
   'ena_base_path'              => 't/data/',
   'pubmed_url_base'            => 't/data/',
-  'taxon_lookup_service'       =>  't/data/',
+  'taxon_lookup_service'       => 't/data/',
   'data_root'                  => 'data',
   'output_root'                => 'ena_updates/',
   'auth_users'                 => ['root','pathpipe','maa','ap13','os7'],
@@ -17,5 +17,6 @@
   'proxy'                      => 'http://wwwcache.sanger.ac.uk:3128',
   'embl_jar_path'              => 't/bin/embl-client.jar',
   'assembly_directories'       => ['/velvet_assembly', '/spades_assembly', '/iva_assembly','/pacbio_assembly'],
-  'annotation_directories'     => ['/velvet_assembly/annotation',  '/spades_assembly/annotation',  '/iva_assembly/annotation', '/pacbio_assembly/annotation']
+  'annotation_directories'     => ['/velvet_assembly/annotation',  '/spades_assembly/annotation',  '/iva_assembly/annotation', '/pacbio_assembly/annotation'],
+  'jvm'                        => 'customjava',
 }


### PR DESCRIPTION
Extract the jvm path from the config file
Minor refactoring: enforce all required args for low level object.  Move defaulting logic with the argument parsing logic