### PR TITLE
Fix validate sample manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 FROM ubuntu:18.04
 MAINTAINER = path-help@sanger.ac.uk
 
-# version of ena-submissions -- SHOULD specify this at build time
-ARG TAG=1.0.8
-
 # dependency versions -- COULD specify these at build time
 ARG VR_CODEBASE_VERSION=0.04
 ARG CONFIG_GENERAL_VERSION=2.52

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:18.04
+MAINTAINER = path-help@sanger.ac.uk
+
+# version of ena-submissions -- SHOULD specify this at build time
+ARG TAG=1.0.8
+
+# dependency versions -- COULD specify these at build time
+ARG VR_CODEBASE_VERSION=0.04
+ARG CONFIG_GENERAL_VERSION=2.52
+
+RUN apt-get update -qq -y
+RUN apt-get upgrade -qq -y
+RUN apt-get install -qq -y \
+    default-jdk \
+    build-essential \
+    git \
+    file \
+    wget \
+    curl \
+    libxml2-dev \
+    libexpat1-dev \
+    libgd-dev \
+    libssl-dev \
+    libdb-dev \
+    libmysqlclient-dev \
+    cpanminus \
+    locales \
+    genometools
+    
+# locales to avoid perl warning
+# RUN cp /usr/share/i18n/SUPPORTED /etc/locale.gen
+# RUN locale-gen
+RUN   sed -i -e 's/# \(en_GB\.UTF-8 .*\)/\1/' /etc/locale.gen && \
+      touch /usr/share/locale/locale.alias && \
+      locale-gen
+ENV   LANG     en_GB.UTF-8
+ENV   LANGUAGE en_GB:en
+ENV   LC_ALL   en_GB.UTF-8
+
+# dzil
+RUN cpanm --notest \
+    Dist::Zilla \
+    Config::General@${CONFIG_GENERAL_VERSION}
+
+# vr-codebase
+RUN cd /opt \
+    && wget -q https://github.com/sanger-pathogens/vr-codebase/archive/v${VR_CODEBASE_VERSION}.tar.gz \
+    && tar xf v${VR_CODEBASE_VERSION}.tar.gz \
+    && rm v${VR_CODEBASE_VERSION}.tar.gz
+ENV PERL5LIB /opt/vr-codebase-${VR_CODEBASE_VERSION}/modules:$PERL5LIB
+
+# bio-ena-datasubmission
+RUN mkdir -p /opt/Bio-ENA-DataSubmission
+COPY . /opt/Bio-ENA-DataSubmission
+ENV PATH /opt/Bio-ENA-DataSubmission/bin:$PATH
+ENV PERL5LIB /opt/Bio-ENA-DataSubmission/lib:$PERL5LIB
+ENV ENA_SUBMISSIONS_DATA /opt/Bio-ENA-DataSubmission/data
+RUN cd /opt/Bio-ENA-DataSubmission && dzil authordeps --missing | cpanm --notest
+RUN cd /opt/Bio-ENA-DataSubmission && dzil listdeps --missing | grep -v 'VRTrack::Lane' | cpanm --notest


### PR DESCRIPTION
Bio::ENA::DataSubmission::CommandLine::ValidateManifest stops looking for errors after the first error is found (_except_ all remaining rows are checked for missing accession numbers).  This looks like a deliberate feature, but it has been reported as a bug: https://trello.com/c/DEdFF155/2-fix-validatesamplemanifest).

Some error checks will crash if attempted when accession number is undefined; this problem was avoided by the feature described above.  The fix needs to preserve this beneficial behaviour.

This merge tweaks the code so that all rows will always be checked for errors; but if any row has a missing accession number, that error is reported but then no further checks are done _on that row_ (a warning is printed to STDERR to alert the user).

Missing out some validation checks should be safe as it only occurs in circumstances where the validation will have failed anyway -- so any unreported errors should be caught when the missing accession number is included, and the validation done again.

